### PR TITLE
update windows binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ julia> Pkg.add("ECOS")
 ECOS.jl will automatically setup the ECOS solver itself:
  - On Linux it will build from source
  - On OS X it will download a binary via [Homebrew.jl].
- - On Windows it will download a binary. [There is currently an issue with the 64-bit version of ECOS on Windows.](https://github.com/JuliaOpt/ECOS.jl/pull/8).
+ - On Windows it will download a binary.
 
 ## Usage
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,17 +9,17 @@ ecos = library_dependency("ecos", aliases=["libecos"])
     provides( Homebrew.HB, "ecos", ecos, os = :Darwin )
 end
 
-# This is the git commit that includes our merged patches as of 07/30/2014
+# This is the git commit that includes our merged patches as of 08/05/2014
 # This is safer than unpacking from master which may cause ECOS.jl to
 # not work properly
-version = "d206a556a83396756f3200964de162b4a7523c62"
+version = "e05a605588c38ad72e843f36af17f8f84e4e2ccb"
 provides(Sources, URI("https://github.com/ifa-ethz/ecos/archive/$version.tar.gz"),
     [ecos], os = :Unix, unpacked_dir="ecos-$version")
 
 prefix = joinpath(BinDeps.depsdir(ecos),"usr")
 srcdir = joinpath(BinDeps.depsdir(ecos),"src","ecos-$version")
 
-provides(Binaries, URI("http://sourceforge.net/projects/juliadeps-win/files/ecos-1.0.3.7z"),
+provides(Binaries, URI("http://sourceforge.net/projects/juliadeps-win/files/ecos-$version.7z"),
     [ecos], unpacked_dir="usr$WORD_SIZE/bin", os = :Windows)
 
 # We'll keep this around for emergencies, but OSX users should be able to use Homebrew


### PR DESCRIPTION
This tests cleanly on both Win32 https://ci.appveyor.com/project/tkelman/ecos-jl/build/1.0.7/job/5sw93vkt40uqnxsx
and Win64 https://ci.appveyor.com/project/tkelman/ecos-jl/build/1.0.7/job/kxqfbv6jgyj14c6i

You can generate these automatically on AppVeyor from a fork of the ECOS repository with this yml: https://github.com/tkelman/ecos/blob/0e53f6e53f38d44b9d8299d6a8faaec7f3dcdf69/appveyor.yml however that's not ideal because it results in a new SHA that doesn't exist upstream.

You probably want to turn on AppVeyor for ECOS.jl for testing purposes, and make sure to either create a new Windows binary and/or copy the existing version number for the sake of the Windows binary next time a Linux version bump is desired.
