### PR TITLE
report suboptimal status

### DIFF
--- a/src/ECOSSolverInterface.jl
+++ b/src/ECOSSolverInterface.jl
@@ -159,6 +159,8 @@ function optimize!(m::ECOSMathProgModel)
         m.solve_stat = :Unbounded
     elseif flag == ECOS_MAXIT
         m.solve_stat = :UserLimit
+    elseif flag == ECOS_OPTIMAL + ECOS_INACC_OFFSET
+        m.solve_stat = :Suboptimal
     else
         m.solve_stat = :Error
     end


### PR DESCRIPTION
ECOS seems to have numerical issues pretty often when exponential cones are involved (https://github.com/embotech/ecos/issues/134). Let's at least pass on the status.
``:Suboptimal`` is also used by Gurobi and CPLEX.