### PR TITLE
update for ECOS 2.0.5

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,7 @@ if is_apple()
     provides( Homebrew.HB, "ecos", ecos, os = :Darwin )
 end
 
-version = "2.0.4"
+version = "2.0.5"
 win_version = "2.0.2"
 provides(Sources, URI("https://github.com/ifa-ethz/ecos/archive/v$version.tar.gz"),
     [ecos], os = :Unix, unpacked_dir="ecos-$version")

--- a/src/ECOS.jl
+++ b/src/ECOS.jl
@@ -20,6 +20,13 @@ else
     error("ECOS not properly installed. Please run Pkg.build(\"ECOS\")")
 end
 
+# ver  [not exported]
+# Returns the version of ECOS in use
+function ver()
+    ver_ptr = ccall((:ECOS_ver, ECOS.ecos), Ptr{UInt8}, ())
+    return unsafe_string(ver_ptr)
+end
+
 macro ecos_ccall(func, args...)
     f = "ECOS_$(func)"
     quote
@@ -170,13 +177,6 @@ end
 # The optional keepvars argument is number of variables to NOT free.
 function cleanup(problem::Ptr{Cpwork}, keepvars::Int = 0)
     ccall((:ECOS_cleanup, ECOS.ecos), Void, (Ptr{Cpwork}, Clong), problem, keepvars)
-end
-
-# ver  [not exported]
-# Returns the version of ECOS in use
-function ver()
-    ver_ptr = ccall((:ECOS_ver, ECOS.ecos), Ptr{UInt8}, ())
-    return unsafe_string(ver_ptr)
 end
 
 end # module

--- a/src/types.jl
+++ b/src/types.jl
@@ -140,87 +140,178 @@ immutable Csettings
     centrality::Cdouble
 end
 
-immutable Cpwork
-    # Dimensions
-    n::Clong
-    m::Clong
-    p::Clong
-    D::Clong
+if VersionNumber(ver()) >= v"2.0.5"
+    @eval immutable Cpwork
+        # Dimensions
+        n::Clong
+        m::Clong
+        p::Clong
+        D::Clong
 
-    # Variables
-    x::Ptr{Cdouble}
-    y::Ptr{Cdouble}
-    z::Ptr{Cdouble}
-    s::Ptr{Cdouble}
-    lambda::Ptr{Cdouble}
-    kap::Cdouble
-    tau::Cdouble
+        # Variables
+        x::Ptr{Cdouble}
+        y::Ptr{Cdouble}
+        z::Ptr{Cdouble}
+        s::Ptr{Cdouble}
+        lambda::Ptr{Cdouble}
+        kap::Cdouble
+        tau::Cdouble
 
-    # Best iterates seen so far
-    best_x::Ptr{Cdouble}
-    best_y::Ptr{Cdouble}
-    best_z::Ptr{Cdouble}
-    best_s::Ptr{Cdouble}
-    best_kap::Cdouble
-    best_tau::Cdouble
-    best_cx::Cdouble
-    best_by::Cdouble
-    best_hz::Cdouble
-    best_info::Ptr{Cstats}
+        # Best iterates seen so far
+        best_x::Ptr{Cdouble}
+        best_y::Ptr{Cdouble}
+        best_z::Ptr{Cdouble}
+        best_s::Ptr{Cdouble}
+        best_kap::Cdouble
+        best_tau::Cdouble
+        best_cx::Cdouble
+        best_by::Cdouble
+        best_hz::Cdouble
+        best_info::Ptr{Cstats}
 
-    # Temporary variables
-    dsaff::Ptr{Cdouble}
-    dzaff::Ptr{Cdouble}
-    W_times_dzaff::Ptr{Cdouble}
-    dsaff_by_W::Ptr{Cdouble}
-    saff::Ptr{Cdouble}
-    zaff::Ptr{Cdouble}
+        # Temporary variables
+        dsaff::Ptr{Cdouble}
+        dzaff::Ptr{Cdouble}
+        W_times_dzaff::Ptr{Cdouble}
+        dsaff_by_W::Ptr{Cdouble}
+        saff::Ptr{Cdouble}
+        zaff::Ptr{Cdouble}
 
-    # Cone
-    C::Ptr{Ccone}
-    A::Ptr{Cspmat}
-    G::Ptr{Cspmat}
-    c::Ptr{Cdouble}
-    b::Ptr{Cdouble}
-    h::Ptr{Cdouble}
+        # Cone
+        C::Ptr{Ccone}
+        A::Ptr{Cspmat}
+        G::Ptr{Cspmat}
+        c::Ptr{Cdouble}
+        b::Ptr{Cdouble}
+        h::Ptr{Cdouble}
 
-    # equilibration vector
-    xequil::Ptr{Cdouble}
-    Aequil::Ptr{Cdouble}
-    Gequil::Ptr{Cdouble}
+        # indices that map entries of A and G to the KKT matrix
+        AtoK::Ptr{Clong}
+        GtoK::Ptr{Clong}
 
-    # scalings of problem data
-    resx0::Cdouble
-    resy0::Cdouble
-    resz0::Cdouble
+        # equilibration vector
+        xequil::Ptr{Cdouble}
+        Aequil::Ptr{Cdouble}
+        Gequil::Ptr{Cdouble}
 
-    # residuals
-    rx::Ptr{Cdouble}
-    ry::Ptr{Cdouble}
-    rz::Ptr{Cdouble}
-    rt::Cdouble
-    hresx::Cdouble
-    hresy::Cdouble
-    hresz::Cdouble
+        # scalings of problem data
+        resx0::Cdouble
+        resy0::Cdouble
+        resz0::Cdouble
 
-    # norm iterates
-    nx::Cdouble
-    ny::Cdouble
-    nz::Cdouble
-    ns::Cdouble
+        # residuals
+        rx::Ptr{Cdouble}
+        ry::Ptr{Cdouble}
+        rz::Ptr{Cdouble}
+        rt::Cdouble
+        hresx::Cdouble
+        hresy::Cdouble
+        hresz::Cdouble
 
-    # temporary storage
-    cx::Cdouble
-    by::Cdouble
-    hz::Cdouble
-    sz::Cdouble
+        # norm iterates
+        nx::Cdouble
+        ny::Cdouble
+        nz::Cdouble
+        ns::Cdouble
 
-    # KKT System
-    KKT::Ptr{Ckkt}
+        # temporary storage
+        cx::Cdouble
+        by::Cdouble
+        hz::Cdouble
+        sz::Cdouble
 
-    # info struct
-    info::Ptr{Cstats}
+        # KKT System
+        KKT::Ptr{Ckkt}
 
-    # settings struct
-    stgs::Ptr{Csettings}
+        # info struct
+        info::Ptr{Cstats}
+
+        # settings struct
+        stgs::Ptr{Csettings}
+    end
+else
+    @eval immutable Cpwork
+        # Dimensions
+        n::Clong
+        m::Clong
+        p::Clong
+        D::Clong
+
+        # Variables
+        x::Ptr{Cdouble}
+        y::Ptr{Cdouble}
+        z::Ptr{Cdouble}
+        s::Ptr{Cdouble}
+        lambda::Ptr{Cdouble}
+        kap::Cdouble
+        tau::Cdouble
+
+        # Best iterates seen so far
+        best_x::Ptr{Cdouble}
+        best_y::Ptr{Cdouble}
+        best_z::Ptr{Cdouble}
+        best_s::Ptr{Cdouble}
+        best_kap::Cdouble
+        best_tau::Cdouble
+        best_cx::Cdouble
+        best_by::Cdouble
+        best_hz::Cdouble
+        best_info::Ptr{Cstats}
+
+        # Temporary variables
+        dsaff::Ptr{Cdouble}
+        dzaff::Ptr{Cdouble}
+        W_times_dzaff::Ptr{Cdouble}
+        dsaff_by_W::Ptr{Cdouble}
+        saff::Ptr{Cdouble}
+        zaff::Ptr{Cdouble}
+
+        # Cone
+        C::Ptr{Ccone}
+        A::Ptr{Cspmat}
+        G::Ptr{Cspmat}
+        c::Ptr{Cdouble}
+        b::Ptr{Cdouble}
+        h::Ptr{Cdouble}
+
+        # equilibration vector
+        xequil::Ptr{Cdouble}
+        Aequil::Ptr{Cdouble}
+        Gequil::Ptr{Cdouble}
+
+        # scalings of problem data
+        resx0::Cdouble
+        resy0::Cdouble
+        resz0::Cdouble
+
+        # residuals
+        rx::Ptr{Cdouble}
+        ry::Ptr{Cdouble}
+        rz::Ptr{Cdouble}
+        rt::Cdouble
+        hresx::Cdouble
+        hresy::Cdouble
+        hresz::Cdouble
+
+        # norm iterates
+        nx::Cdouble
+        ny::Cdouble
+        nz::Cdouble
+        ns::Cdouble
+
+        # temporary storage
+        cx::Cdouble
+        by::Cdouble
+        hz::Cdouble
+        sz::Cdouble
+
+        # KKT System
+        KKT::Ptr{Ckkt}
+
+        # info struct
+        info::Ptr{Cstats}
+
+        # settings struct
+        stgs::Ptr{Csettings}
+    end
 end


### PR DESCRIPTION
ECOS 2.0.4 has a bug that results in incorrect answers on Pajarito's unit tests (https://github.com/mlubin/Pajarito.jl/issues/102), so we need to bump ECOS. I made the update so that the code still works with older versions, but we should update the windows and OS X binaries ASAP.

CC @tkelman @staticfloat @chriscoey