### PR TITLE
✅ Enable solve_blank_obj fixed in MOI v0.6.2

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 MathProgBase 0.5 0.8
-MathOptInterface 0.6 0.7
+MathOptInterface 0.6.2 0.7
 Compat 0.68
 BinaryProvider 0.3

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -2,3 +2,4 @@ deps.jl
 downloads/
 src/
 usr/
+build.log

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -21,11 +21,7 @@ const config = MOIT.TestConfig(atol=1e-4, rtol=1e-4)
 
 @testset "Unit" begin
     MOIT.unittest(MOIB.SplitInterval{Float64}(optimizer), config,
-                  [# FIXME The solution of solve_blank_obj is arbitrary,
-                   # ECOS finds 2 instead of the expected 1 but it cannot be
-                   # blamed
-                   "solve_blank_obj",
-                   # Quadratic functions are not supported
+                  [# Quadratic functions are not supported
                    "solve_qcp_edge_cases", "solve_qp_edge_cases",
                    # Integer and ZeroOne sets are not supported
                    "solve_integer_edge_cases", "solve_objbound_edge_cases"])


### PR DESCRIPTION
It was resolved in https://github.com/JuliaOpt/MathOptInterface.jl/pull/537